### PR TITLE
Fix error when % is passed as only string

### DIFF
--- a/_printf.c
+++ b/_printf.c
@@ -13,7 +13,7 @@ int _printf(const char *format, ...)
 	int len;
 	va_list args;
 
-	if (format == NULL)
+	if (format == NULL || (*format == '%' && format[1] == '\0'))
 		return (-1);
 	va_start(args, format);
 	len = _vprintf(format, args);


### PR DESCRIPTION
* program now handle passeding the % sign as only argument
* return -1 to signify an error